### PR TITLE
chore: release v0.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,23 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.3.1](https://github.com/0xCCF4/BackupDeduplicator/compare/v0.3.0...v0.3.1) - 2024-07-01
+
+### Added
+- *(ci)* added release-plz, devskim, auto-merge for dependabot and dependabot for ci
+
+### Other
+- *(deps)* Bump clap from 4.5.4 to 4.5.8 ([#19](https://github.com/0xCCF4/BackupDeduplicator/pull/19))
+- Bump log from 0.4.21 to 0.4.22 ([#20](https://github.com/0xCCF4/BackupDeduplicator/pull/20))
+- *(deps)* bump serde_json from 1.0.117 to 1.0.120 ([#22](https://github.com/0xCCF4/BackupDeduplicator/pull/22))
+- Bump serde_json from 1.0.116 to 1.0.117 ([#13](https://github.com/0xCCF4/BackupDeduplicator/pull/13))
+- Bump anyhow from 1.0.82 to 1.0.86 ([#16](https://github.com/0xCCF4/BackupDeduplicator/pull/16))
+- Bump serde from 1.0.199 to 1.0.203 ([#17](https://github.com/0xCCF4/BackupDeduplicator/pull/17))
+- Bump serde from 1.0.198 to 1.0.199
+- Bump serde_json from 1.0.115 to 1.0.116
+- Bump serde from 1.0.197 to 1.0.198

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -67,7 +67,7 @@ checksum = "b3d1d046238990b9cf5bcde22a3fb3584ee5cf65fb2765f454ed428c7a0063da"
 
 [[package]]
 name = "backup-deduplicator"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "backup-deduplicator"
-version = "0.3.0"
+version = "0.3.1"
 edition = "2021"
 description = """
 A tool to deduplicate backups. It builds a hash tree of all files and folders


### PR DESCRIPTION
## 🤖 New release
* `backup-deduplicator`: 0.3.0 -> 0.3.1

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.3.1](https://github.com/0xCCF4/BackupDeduplicator/compare/v0.3.0...v0.3.1) - 2024-07-01

### Added
- *(ci)* added release-plz, devskim, auto-merge for dependabot and dependabot for ci

### Other
- *(deps)* Bump clap from 4.5.4 to 4.5.8 ([#19](https://github.com/0xCCF4/BackupDeduplicator/pull/19))
- Bump log from 0.4.21 to 0.4.22 ([#20](https://github.com/0xCCF4/BackupDeduplicator/pull/20))
- *(deps)* bump serde_json from 1.0.117 to 1.0.120 ([#22](https://github.com/0xCCF4/BackupDeduplicator/pull/22))
- Bump serde_json from 1.0.116 to 1.0.117 ([#13](https://github.com/0xCCF4/BackupDeduplicator/pull/13))
- Bump anyhow from 1.0.82 to 1.0.86 ([#16](https://github.com/0xCCF4/BackupDeduplicator/pull/16))
- Bump serde from 1.0.199 to 1.0.203 ([#17](https://github.com/0xCCF4/BackupDeduplicator/pull/17))
- Bump serde from 1.0.198 to 1.0.199
- Bump serde_json from 1.0.115 to 1.0.116
- Bump serde from 1.0.197 to 1.0.198
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).